### PR TITLE
Task/#33 Erweiterung der Desires und SubDesires um eine Referenz auf den Agenten für Zugriff auf Beliefs

### DIFF
--- a/src/main/java/de/feu/massim22/group3/agents/BdiAgent.java
+++ b/src/main/java/de/feu/massim22/group3/agents/BdiAgent.java
@@ -22,4 +22,7 @@ public abstract class BdiAgent extends Agent {
         // TODO return default if intention == null
         return intention;
     }
+    public Belief getAgentBelief() {
+        return belief;
+    }
 }

--- a/src/main/java/de/feu/massim22/group3/agents/Belief.java
+++ b/src/main/java/de/feu/massim22/group3/agents/Belief.java
@@ -569,7 +569,7 @@ public class Belief {
     private record ReachableRoleZone(Point position, int distance, int direction) {
         public String toString() {
             String dir = DirectionUtil.intToStringDirection(direction);
-            return "Reachable Goalzone at (" + position.x + "/" + position.y + ") with distance " + distance + " in direction " + dir;
+            return "Reachable Rolezone at (" + position.x + "/" + position.y + ") with distance " + distance + " in direction " + dir;
         }
     }
 

--- a/src/main/java/de/feu/massim22/group3/agents/Belief.java
+++ b/src/main/java/de/feu/massim22/group3/agents/Belief.java
@@ -249,78 +249,90 @@ public class Belief {
         }
     }
 
-    int getVision() {
+    public int getVision() {
         Role r = roles.get(role);
         if (r == null) { throw new IllegalArgumentException("Current role is not in existing roles"); }
         return r.vision();
     }
     
-    int getStep() {
+    public int getStep() {
         return step;
     }
 
-    Set<Thing> getThings() {
+    public Set<Thing> getThings() {
         return things;
     }
 
-    Set<TaskInfo> getTaskInfo() {
+    public Set<TaskInfo> getTaskInfo() {
         return taskInfo;
     }
 
-    Set<NormInfo> getNormsInfo() {
+    public Set<NormInfo> getNormsInfo() {
         return normsInfo;
     }
 
-    long getScore() {
+    public long getScore() {
         return score;
     }
 
-    String getLastAction() {
+    public String getLastAction() {
         return lastAction;
     }
 
-    String getLastActionResult() {
+    public String getLastActionResult() {
         return lastActionResult;
     }
 
-    List<String> getLastActionParams() {
+    public List<String> getLastActionParams() {
         return lastActionParams;
     }
 
-    List<Point> getAttachedThings() {
+    public List<Point> getAttachedThings() {
         return attachedThings;
     }
 
-    int getEnergy() {
+    public int getEnergy() {
         return energy;
     }
 
-    boolean isDeactivated() {
+    public boolean isDeactivated() {
         return deactivated;
     }
 
-    String getRole() {
+    public String getRole() {
         return role;
     }
 
-    List<StepEvent> getStepEvents() {
+    public List<StepEvent> getStepEvents() {
         return stepEvents;
     }
 
-    List<String> getViolations() {
+    public List<String> getViolations() {
         return violations;
     }
 
-    List<Point> getGoalZones() {
+    public List<Point> getGoalZones() {
         return goalZones;
     }
 
-    List<Point> getRoleZones() {
+    public List<Point> getRoleZones() {
         return roleZones;
     }
 
-    Point getPosition() {
+    public Point getPosition() {
         return position;
+    }
+
+    public List<ReachableDispenser> getReachableDispensers(){
+        return reachableDispensers;
+    }
+
+    public List<ReachableGoalZone> getReachableGoalZones(){
+        return reachableGoalZones;
+    }
+
+    public List<ReachableRoleZone> getReachableRoleZones(){
+        return reachableRoleZones;
     }
 
     void setPosition(Point position) {

--- a/src/main/java/de/feu/massim22/group3/agents/DesireHandler.java
+++ b/src/main/java/de/feu/massim22/group3/agents/DesireHandler.java
@@ -22,7 +22,7 @@ class DesireHandler {
     }
 
     public void setTeamGoal(Desires newDesire) {
-        currentTeamGoal = newDesire.getDesireObj();
+        currentTeamGoal = newDesire.getDesireObj(agent);
     }
 
     public void setNextAction() {
@@ -72,15 +72,15 @@ class DesireHandler {
 
     // Define high priority goals and their order here
     private void setHighPrioAgentGoals() {
-        this.highPrioAgentGoals.add(Desires.DIG_FREE.getDesireObj());
-        this.highPrioAgentGoals.add(Desires.DODGE_CLEAR.getDesireObj());
-        this.highPrioAgentGoals.add(Desires.DODGE_OTHER_AGENT.getDesireObj());
-        this.highPrioAgentGoals.add(Desires.REACT_TO_NORM.getDesireObj());
+        this.highPrioAgentGoals.add(Desires.DIG_FREE.getDesireObj(agent));
+        this.highPrioAgentGoals.add(Desires.DODGE_CLEAR.getDesireObj(agent));
+        this.highPrioAgentGoals.add(Desires.DODGE_OTHER_AGENT.getDesireObj(agent));
+        this.highPrioAgentGoals.add(Desires.REACT_TO_NORM.getDesireObj(agent));
     }
 
     // Define low priority goals and their order here
     private void setLowPrioAgentGoals() {
-        this.lowPrioAgentGoals.add(Desires.SPONTANEOUS_HINDER_ENEMY.getDesireObj());
-        this.lowPrioAgentGoals.add(Desires.GO_TO_UNKNOWN_AREA.getDesireObj());
+        this.lowPrioAgentGoals.add(Desires.SPONTANEOUS_HINDER_ENEMY.getDesireObj(agent));
+        this.lowPrioAgentGoals.add(Desires.GO_TO_UNKNOWN_AREA.getDesireObj(agent));
     }
 }

--- a/src/main/java/de/feu/massim22/group3/agents/Desires/AttackEnemyDesire.java
+++ b/src/main/java/de/feu/massim22/group3/agents/Desires/AttackEnemyDesire.java
@@ -1,9 +1,11 @@
 package de.feu.massim22.group3.agents.Desires;
 
+import de.feu.massim22.group3.agents.BdiAgent;
+
 public class AttackEnemyDesire extends Desire {
 
-    public AttackEnemyDesire() {
-        super();
+    public AttackEnemyDesire(BdiAgent agent) {
+        super(agent);
     }
 
     @Override

--- a/src/main/java/de/feu/massim22/group3/agents/Desires/Desire.java
+++ b/src/main/java/de/feu/massim22/group3/agents/Desires/Desire.java
@@ -3,14 +3,17 @@ package de.feu.massim22.group3.agents.Desires;
 import java.util.LinkedList;
 import java.util.List;
 
+import de.feu.massim22.group3.agents.BdiAgent;
 import de.feu.massim22.group3.agents.Desires.SubDesires.SubDesire;
 
 public abstract class Desire {
 
     protected Desires desireType;
     protected List<SubDesire> subDesires = new LinkedList<SubDesire>();
+    protected BdiAgent agent;
 
-    Desire() {
+    Desire(BdiAgent agent) {
+        this.agent = agent;
         setType();
         defineSubDesires();
     }

--- a/src/main/java/de/feu/massim22/group3/agents/Desires/Desires.java
+++ b/src/main/java/de/feu/massim22/group3/agents/Desires/Desires.java
@@ -1,5 +1,7 @@
 package de.feu.massim22.group3.agents.Desires;
 
+import de.feu.massim22.group3.agents.BdiAgent;
+
 public enum Desires {
     // Team Desires
     PROCESS_TASK,
@@ -16,32 +18,32 @@ public enum Desires {
     SPONTANEOUS_HINDER_ENEMY,
     GO_TO_UNKNOWN_AREA,;
 
-    public Desire getDesireObj() {
+    public Desire getDesireObj(BdiAgent agent) {
         switch (this) {
         case PROCESS_TASK:
-            return new ProcessTaskDesire();
+            return new ProcessTaskDesire(agent);
         case ATTACK_ENEMY:
-            return new AttackEnemyDesire();
+            return new AttackEnemyDesire(agent);
         case DETERMINE_MAP_SIZE:
-            return new DetermineMapSizeDesire();
+            return new DetermineMapSizeDesire(agent);
         case EXPLORE_MAP:
-            return new ExploreMapDesire();
+            return new ExploreMapDesire(agent);
         case GOAL_ZONE_GUARD:
-            return new GoalZoneGuardDesire();
+            return new GoalZoneGuardDesire(agent);
         case HELP_TASK_AGENT:
-            return new HelpTaskAgentDesire();
+            return new HelpTaskAgentDesire(agent);
         case DIG_FREE:
-            return new DigFreeDesire();
+            return new DigFreeDesire(agent);
         case DODGE_CLEAR:
-            return new DogeClearDesire();
+            return new DogeClearDesire(agent);
         case DODGE_OTHER_AGENT:
-            return new DogeOtherAgentDesire();
+            return new DogeOtherAgentDesire(agent);
         case REACT_TO_NORM:
-            return new ReactToNormDesire();
+            return new ReactToNormDesire(agent);
         case SPONTANEOUS_HINDER_ENEMY:
-            return new SpontaneousHinderEnemyDesire();
+            return new SpontaneousHinderEnemyDesire(agent);
         case GO_TO_UNKNOWN_AREA:
-            return new GoToUnknownAreaDesire();
+            return new GoToUnknownAreaDesire(agent);
         default: {
             throw new IllegalArgumentException("Unknown type during Desire instantiation.");
         }

--- a/src/main/java/de/feu/massim22/group3/agents/Desires/DetermineMapSizeDesire.java
+++ b/src/main/java/de/feu/massim22/group3/agents/Desires/DetermineMapSizeDesire.java
@@ -1,9 +1,11 @@
 package de.feu.massim22.group3.agents.Desires;
 
+import de.feu.massim22.group3.agents.BdiAgent;
+
 public class DetermineMapSizeDesire extends Desire {
 
-    public DetermineMapSizeDesire() {
-        super();
+    public DetermineMapSizeDesire(BdiAgent agent) {
+        super(agent);
     }
 
     @Override

--- a/src/main/java/de/feu/massim22/group3/agents/Desires/DigFreeDesire.java
+++ b/src/main/java/de/feu/massim22/group3/agents/Desires/DigFreeDesire.java
@@ -1,16 +1,17 @@
 package de.feu.massim22.group3.agents.Desires;
 
 import de.feu.massim22.group3.agents.Desires.SubDesires.SubDesires;
+import de.feu.massim22.group3.agents.BdiAgent;
 
 public class DigFreeDesire extends Desire {
 
-    public DigFreeDesire() {
-        super();
+    public DigFreeDesire(BdiAgent agent) {
+        super(agent);
     }
 
     @Override
     void defineSubDesires() {
-        subDesires.add(SubDesires.DIG_FREE.getSubDesireObj());
+        subDesires.add(SubDesires.DIG_FREE.getSubDesireObj(agent));
     }
     void setType() {
         this.desireType = Desires.DIG_FREE;

--- a/src/main/java/de/feu/massim22/group3/agents/Desires/DogeClearDesire.java
+++ b/src/main/java/de/feu/massim22/group3/agents/Desires/DogeClearDesire.java
@@ -1,16 +1,17 @@
 package de.feu.massim22.group3.agents.Desires;
 
 import de.feu.massim22.group3.agents.Desires.SubDesires.SubDesires;
+import de.feu.massim22.group3.agents.BdiAgent;
 
 public class DogeClearDesire extends Desire {
 
-    public DogeClearDesire() {
-        super();
+    public DogeClearDesire(BdiAgent agent) {
+        super(agent);
     }
 
     @Override
     void defineSubDesires() {
-        subDesires.add(SubDesires.DODGE_CLEAR.getSubDesireObj());
+        subDesires.add(SubDesires.DODGE_CLEAR.getSubDesireObj(agent));
     }
     void setType() {
         this.desireType = Desires.DODGE_CLEAR;

--- a/src/main/java/de/feu/massim22/group3/agents/Desires/DogeOtherAgentDesire.java
+++ b/src/main/java/de/feu/massim22/group3/agents/Desires/DogeOtherAgentDesire.java
@@ -1,16 +1,17 @@
 package de.feu.massim22.group3.agents.Desires;
 
 import de.feu.massim22.group3.agents.Desires.SubDesires.SubDesires;
+import de.feu.massim22.group3.agents.BdiAgent;
 
 public class DogeOtherAgentDesire extends Desire {
 
-    public DogeOtherAgentDesire() {
-        super();
+    public DogeOtherAgentDesire(BdiAgent agent) {
+        super(agent);
     }
 
     @Override
     void defineSubDesires() {
-        subDesires.add(SubDesires.DODGE_OTHER_AGENT.getSubDesireObj());
+        subDesires.add(SubDesires.DODGE_OTHER_AGENT.getSubDesireObj(agent));
     }
     void setType() {
         this.desireType = Desires.DODGE_OTHER_AGENT;

--- a/src/main/java/de/feu/massim22/group3/agents/Desires/ExploreMapDesire.java
+++ b/src/main/java/de/feu/massim22/group3/agents/Desires/ExploreMapDesire.java
@@ -1,9 +1,11 @@
 package de.feu.massim22.group3.agents.Desires;
 
+import de.feu.massim22.group3.agents.BdiAgent;
+
 public class ExploreMapDesire extends Desire {
 
-    public ExploreMapDesire() {
-        super();
+    public ExploreMapDesire(BdiAgent agent) {
+        super(agent);
     }
 
     @Override

--- a/src/main/java/de/feu/massim22/group3/agents/Desires/GoToUnknownAreaDesire.java
+++ b/src/main/java/de/feu/massim22/group3/agents/Desires/GoToUnknownAreaDesire.java
@@ -1,16 +1,17 @@
 package de.feu.massim22.group3.agents.Desires;
 
 import de.feu.massim22.group3.agents.Desires.SubDesires.SubDesires;
+import de.feu.massim22.group3.agents.BdiAgent;
 
 public class GoToUnknownAreaDesire extends Desire {
 
-    public GoToUnknownAreaDesire() {
-        super();
+    public GoToUnknownAreaDesire(BdiAgent agent) {
+        super(agent);
     }
 
     @Override
     void defineSubDesires() {
-        subDesires.add(SubDesires.GO_TO_UNKNOWN_AREA.getSubDesireObj());
+        subDesires.add(SubDesires.GO_TO_UNKNOWN_AREA.getSubDesireObj(agent));
     }
     void setType() {
         this.desireType = Desires.GO_TO_UNKNOWN_AREA;

--- a/src/main/java/de/feu/massim22/group3/agents/Desires/GoalZoneGuardDesire.java
+++ b/src/main/java/de/feu/massim22/group3/agents/Desires/GoalZoneGuardDesire.java
@@ -1,9 +1,11 @@
 package de.feu.massim22.group3.agents.Desires;
 
+import de.feu.massim22.group3.agents.BdiAgent;
+
 public class GoalZoneGuardDesire extends Desire {
 
-    public GoalZoneGuardDesire() {
-        super();
+    public GoalZoneGuardDesire(BdiAgent agent) {
+        super(agent);
     }
 
     @Override

--- a/src/main/java/de/feu/massim22/group3/agents/Desires/HelpTaskAgentDesire.java
+++ b/src/main/java/de/feu/massim22/group3/agents/Desires/HelpTaskAgentDesire.java
@@ -1,9 +1,10 @@
 package de.feu.massim22.group3.agents.Desires;
+import de.feu.massim22.group3.agents.BdiAgent;
 
 public class HelpTaskAgentDesire extends Desire {
 
-    public HelpTaskAgentDesire() {
-        super();
+    public HelpTaskAgentDesire(BdiAgent agent) {
+        super(agent);
     }
 
     @Override

--- a/src/main/java/de/feu/massim22/group3/agents/Desires/ProcessTaskDesire.java
+++ b/src/main/java/de/feu/massim22/group3/agents/Desires/ProcessTaskDesire.java
@@ -1,21 +1,22 @@
 package de.feu.massim22.group3.agents.Desires;
 
 import de.feu.massim22.group3.agents.Desires.SubDesires.SubDesires;
+import de.feu.massim22.group3.agents.BdiAgent;
 
 public class ProcessTaskDesire extends Desire {
 
-    public ProcessTaskDesire() {
-        super();
+    public ProcessTaskDesire(BdiAgent agent) {
+        super(agent);
     }
 
     @Override
     void defineSubDesires() {
-        subDesires.add(SubDesires.GET_ROLE.getSubDesireObj());
-        subDesires.add(SubDesires.CHOOSE_TASK.getSubDesireObj());
-        subDesires.add(SubDesires.GET_BLOCKS.getSubDesireObj());
-        subDesires.add(SubDesires.ASSEMBLE_TASK.getSubDesireObj());
-        subDesires.add(SubDesires.GO_TO_GOAL_AREA.getSubDesireObj());
-        subDesires.add(SubDesires.SUBMIT_TASK.getSubDesireObj());
+        subDesires.add(SubDesires.GET_ROLE.getSubDesireObj(agent));
+        subDesires.add(SubDesires.CHOOSE_TASK.getSubDesireObj(agent));
+        subDesires.add(SubDesires.GET_BLOCKS.getSubDesireObj(agent));
+        subDesires.add(SubDesires.ASSEMBLE_TASK.getSubDesireObj(agent));
+        subDesires.add(SubDesires.GO_TO_GOAL_AREA.getSubDesireObj(agent));
+        subDesires.add(SubDesires.SUBMIT_TASK.getSubDesireObj(agent));
     }
     void setType() {
         this.desireType = Desires.PROCESS_TASK;

--- a/src/main/java/de/feu/massim22/group3/agents/Desires/ReactToNormDesire.java
+++ b/src/main/java/de/feu/massim22/group3/agents/Desires/ReactToNormDesire.java
@@ -1,16 +1,17 @@
 package de.feu.massim22.group3.agents.Desires;
 
 import de.feu.massim22.group3.agents.Desires.SubDesires.SubDesires;
+import de.feu.massim22.group3.agents.BdiAgent;
 
 public class ReactToNormDesire extends Desire {
 
-    public ReactToNormDesire() {
-        super();
+    public ReactToNormDesire(BdiAgent agent) {
+        super(agent);
     }
 
     @Override
     void defineSubDesires() {
-        subDesires.add(SubDesires.REACT_TO_NORM.getSubDesireObj());
+        subDesires.add(SubDesires.REACT_TO_NORM.getSubDesireObj(agent));
     }
     void setType() {
         this.desireType = Desires.REACT_TO_NORM;

--- a/src/main/java/de/feu/massim22/group3/agents/Desires/SpontaneousHinderEnemyDesire.java
+++ b/src/main/java/de/feu/massim22/group3/agents/Desires/SpontaneousHinderEnemyDesire.java
@@ -1,16 +1,17 @@
 package de.feu.massim22.group3.agents.Desires;
 
 import de.feu.massim22.group3.agents.Desires.SubDesires.SubDesires;
+import de.feu.massim22.group3.agents.BdiAgent;
 
 public class SpontaneousHinderEnemyDesire extends Desire {
 
-    public SpontaneousHinderEnemyDesire() {
-        super();
+    public SpontaneousHinderEnemyDesire(BdiAgent agent) {
+        super(agent);
     }
 
     @Override
     void defineSubDesires() {
-        subDesires.add(SubDesires.SPONTANEOUS_HINDER_ENEMY.getSubDesireObj());
+        subDesires.add(SubDesires.SPONTANEOUS_HINDER_ENEMY.getSubDesireObj(agent));
     }
     void setType() {
         this.desireType = Desires.SPONTANEOUS_HINDER_ENEMY;

--- a/src/main/java/de/feu/massim22/group3/agents/Desires/SubDesires/AssembleTaskSubDesire.java
+++ b/src/main/java/de/feu/massim22/group3/agents/Desires/SubDesires/AssembleTaskSubDesire.java
@@ -1,11 +1,12 @@
 package de.feu.massim22.group3.agents.Desires.SubDesires;
 
 import eis.iilang.Action;
+import de.feu.massim22.group3.agents.BdiAgent;
 
 public class AssembleTaskSubDesire extends SubDesire {
 
-    public AssembleTaskSubDesire() {
-        super();
+    public AssembleTaskSubDesire(BdiAgent agent) {
+        super(agent);
     }
 
     @Override

--- a/src/main/java/de/feu/massim22/group3/agents/Desires/SubDesires/ChooseTaskSubDesire.java
+++ b/src/main/java/de/feu/massim22/group3/agents/Desires/SubDesires/ChooseTaskSubDesire.java
@@ -1,11 +1,12 @@
 package de.feu.massim22.group3.agents.Desires.SubDesires;
 
 import eis.iilang.Action;
+import de.feu.massim22.group3.agents.BdiAgent;
 
 public class ChooseTaskSubDesire extends SubDesire {
 
-    public ChooseTaskSubDesire() {
-        super();
+    public ChooseTaskSubDesire(BdiAgent agent) {
+        super(agent);
     }
 
     @Override

--- a/src/main/java/de/feu/massim22/group3/agents/Desires/SubDesires/DigFreeSubDesire.java
+++ b/src/main/java/de/feu/massim22/group3/agents/Desires/SubDesires/DigFreeSubDesire.java
@@ -1,11 +1,12 @@
 package de.feu.massim22.group3.agents.Desires.SubDesires;
 
 import eis.iilang.Action;
+import de.feu.massim22.group3.agents.BdiAgent;
 
 public class DigFreeSubDesire extends SubDesire {
 
-    public DigFreeSubDesire() {
-        super();
+    public DigFreeSubDesire(BdiAgent agent) {
+        super(agent);
     }
 
     @Override

--- a/src/main/java/de/feu/massim22/group3/agents/Desires/SubDesires/DodgeClearSubDesire.java
+++ b/src/main/java/de/feu/massim22/group3/agents/Desires/SubDesires/DodgeClearSubDesire.java
@@ -1,11 +1,12 @@
 package de.feu.massim22.group3.agents.Desires.SubDesires;
 
 import eis.iilang.Action;
+import de.feu.massim22.group3.agents.BdiAgent;
 
 public class DodgeClearSubDesire extends SubDesire {
 
-    public DodgeClearSubDesire() {
-        super();
+    public DodgeClearSubDesire(BdiAgent agent) {
+        super(agent);
     }
 
     @Override

--- a/src/main/java/de/feu/massim22/group3/agents/Desires/SubDesires/DodgeOtherAgentSubDesire.java
+++ b/src/main/java/de/feu/massim22/group3/agents/Desires/SubDesires/DodgeOtherAgentSubDesire.java
@@ -1,11 +1,12 @@
 package de.feu.massim22.group3.agents.Desires.SubDesires;
 
 import eis.iilang.Action;
+import de.feu.massim22.group3.agents.BdiAgent;
 
 public class DodgeOtherAgentSubDesire extends SubDesire {
 
-    public DodgeOtherAgentSubDesire() {
-        super();
+    public DodgeOtherAgentSubDesire(BdiAgent agent) {
+        super(agent);
     }
 
     @Override

--- a/src/main/java/de/feu/massim22/group3/agents/Desires/SubDesires/GetBlocksSubDesire.java
+++ b/src/main/java/de/feu/massim22/group3/agents/Desires/SubDesires/GetBlocksSubDesire.java
@@ -1,12 +1,12 @@
 package de.feu.massim22.group3.agents.Desires.SubDesires;
 
+import de.feu.massim22.group3.agents.BdiAgent;
 import eis.iilang.Action;
-import eis.iilang.Identifier;
 
 public class GetBlocksSubDesire extends SubDesire {
 
-    public GetBlocksSubDesire() {
-        super();
+    public GetBlocksSubDesire(BdiAgent agent) {
+        super(agent);
     }
 
     @Override

--- a/src/main/java/de/feu/massim22/group3/agents/Desires/SubDesires/GetRoleSubDesire.java
+++ b/src/main/java/de/feu/massim22/group3/agents/Desires/SubDesires/GetRoleSubDesire.java
@@ -1,20 +1,21 @@
 package de.feu.massim22.group3.agents.Desires.SubDesires;
 
+import de.feu.massim22.group3.agents.BdiAgent;
 import eis.iilang.Action;
 import eis.iilang.Identifier;
 
 public class GetRoleSubDesire extends SubDesire {
 
-    private String role;
+    private String requiredRole;
 
-    public GetRoleSubDesire() {
-        super();
+    public GetRoleSubDesire(BdiAgent agent) {
+        super(agent);
     }
 
-    public void setRoleToGet(String role) {
+    public void setRoleToGet(String requiredRole) {
         // TODO where is the assignment of roles to Desires defined? Maybe active Norms
         // should be checked too;
-        this.role = role;
+        this.requiredRole = requiredRole;
     }
 
     @Override

--- a/src/main/java/de/feu/massim22/group3/agents/Desires/SubDesires/GoToGoalAreaSubDesire.java
+++ b/src/main/java/de/feu/massim22/group3/agents/Desires/SubDesires/GoToGoalAreaSubDesire.java
@@ -1,11 +1,12 @@
 package de.feu.massim22.group3.agents.Desires.SubDesires;
 
+import de.feu.massim22.group3.agents.BdiAgent;
 import eis.iilang.Action;
 
 public class GoToGoalAreaSubDesire extends SubDesire {
 
-    public GoToGoalAreaSubDesire() {
-        super();
+    public GoToGoalAreaSubDesire(BdiAgent agent) {
+        super(agent);
     }
 
     @Override

--- a/src/main/java/de/feu/massim22/group3/agents/Desires/SubDesires/GoToUnkownAreaSubDesire.java
+++ b/src/main/java/de/feu/massim22/group3/agents/Desires/SubDesires/GoToUnkownAreaSubDesire.java
@@ -1,12 +1,13 @@
 package de.feu.massim22.group3.agents.Desires.SubDesires;
 
+import de.feu.massim22.group3.agents.BdiAgent;
 import eis.iilang.Action;
 import eis.iilang.Identifier;
 
 public class GoToUnkownAreaSubDesire extends SubDesire {
 
-    public GoToUnkownAreaSubDesire() {
-        super();
+    public GoToUnkownAreaSubDesire(BdiAgent agent) {
+        super(agent);
     }
 
     @Override

--- a/src/main/java/de/feu/massim22/group3/agents/Desires/SubDesires/ReactToNormSubDesire.java
+++ b/src/main/java/de/feu/massim22/group3/agents/Desires/SubDesires/ReactToNormSubDesire.java
@@ -1,11 +1,12 @@
 package de.feu.massim22.group3.agents.Desires.SubDesires;
 
+import de.feu.massim22.group3.agents.BdiAgent;
 import eis.iilang.Action;
 
 public class ReactToNormSubDesire extends SubDesire {
 
-    public ReactToNormSubDesire() {
-        super();
+    public ReactToNormSubDesire(BdiAgent agent) {
+        super(agent);
     }
 
     @Override

--- a/src/main/java/de/feu/massim22/group3/agents/Desires/SubDesires/SpontaneousHinderEnemySubDesire.java
+++ b/src/main/java/de/feu/massim22/group3/agents/Desires/SubDesires/SpontaneousHinderEnemySubDesire.java
@@ -1,11 +1,12 @@
 package de.feu.massim22.group3.agents.Desires.SubDesires;
 
+import de.feu.massim22.group3.agents.BdiAgent;
 import eis.iilang.Action;
 
 public class SpontaneousHinderEnemySubDesire extends SubDesire {
 
-    public SpontaneousHinderEnemySubDesire() {
-        super();
+    public SpontaneousHinderEnemySubDesire(BdiAgent agent) {
+        super(agent);
     }
 
     @Override

--- a/src/main/java/de/feu/massim22/group3/agents/Desires/SubDesires/SubDesire.java
+++ b/src/main/java/de/feu/massim22/group3/agents/Desires/SubDesires/SubDesire.java
@@ -3,13 +3,16 @@ package de.feu.massim22.group3.agents.Desires.SubDesires;
 import java.util.LinkedList;
 
 import de.feu.massim22.group3.agents.Desires.Desires;
+import de.feu.massim22.group3.agents.BdiAgent;
 import eis.iilang.Action;
 
 public abstract class SubDesire {
 
     protected SubDesires subDesireType;
+    BdiAgent agent;
 
-    SubDesire() {
+    SubDesire(BdiAgent agent) {
+        this.agent = agent;
         setType();
     }
 

--- a/src/main/java/de/feu/massim22/group3/agents/Desires/SubDesires/SubDesires.java
+++ b/src/main/java/de/feu/massim22/group3/agents/Desires/SubDesires/SubDesires.java
@@ -1,5 +1,7 @@
 package de.feu.massim22.group3.agents.Desires.SubDesires;
 
+import de.feu.massim22.group3.agents.BdiAgent;
+
 public enum SubDesires {
     DIG_FREE,
     DODGE_CLEAR,
@@ -14,32 +16,32 @@ public enum SubDesires {
     SUBMIT_TASK,
     REACT_TO_NORM,;
 
-    public SubDesire getSubDesireObj() {
+    public SubDesire getSubDesireObj(BdiAgent agent) {
         switch (this) {
         case DIG_FREE:
-            return new DigFreeSubDesire();
+            return new DigFreeSubDesire(agent);
         case DODGE_CLEAR:
-            return new DodgeClearSubDesire();
+            return new DodgeClearSubDesire(agent);
         case DODGE_OTHER_AGENT:
-            return new DodgeOtherAgentSubDesire();
+            return new DodgeOtherAgentSubDesire(agent);
         case SPONTANEOUS_HINDER_ENEMY:
-            return new SpontaneousHinderEnemySubDesire();
+            return new SpontaneousHinderEnemySubDesire(agent);
         case GO_TO_UNKNOWN_AREA:
-            return new GoToUnkownAreaSubDesire();
+            return new GoToUnkownAreaSubDesire(agent);
         case GET_ROLE:
-            return new GetRoleSubDesire();
+            return new GetRoleSubDesire(agent);
         case CHOOSE_TASK:
-            return new ChooseTaskSubDesire();
+            return new ChooseTaskSubDesire(agent);
         case GET_BLOCKS:
-            return new GetBlocksSubDesire();
+            return new GetBlocksSubDesire(agent);
         case ASSEMBLE_TASK:
-            return new AssembleTaskSubDesire();
+            return new AssembleTaskSubDesire(agent);
         case GO_TO_GOAL_AREA:
-            return new GoToGoalAreaSubDesire();
+            return new GoToGoalAreaSubDesire(agent);
         case SUBMIT_TASK:
-            return new SubmitTaskSubDesire();
+            return new SubmitTaskSubDesire(agent);
         case REACT_TO_NORM:
-            return new ReactToNormSubDesire();
+            return new ReactToNormSubDesire(agent);
         default: {
             throw new IllegalArgumentException("Unknown type in during SubDesire instantiation.");
         }

--- a/src/main/java/de/feu/massim22/group3/agents/Desires/SubDesires/SubmitTaskSubDesire.java
+++ b/src/main/java/de/feu/massim22/group3/agents/Desires/SubDesires/SubmitTaskSubDesire.java
@@ -1,11 +1,12 @@
 package de.feu.massim22.group3.agents.Desires.SubDesires;
 
+import de.feu.massim22.group3.agents.BdiAgent;
 import eis.iilang.Action;
 
 public class SubmitTaskSubDesire extends SubDesire {
 
-    public SubmitTaskSubDesire() {
-        super();
+    public SubmitTaskSubDesire(BdiAgent agent) {
+        super(agent);
     }
 
     @Override


### PR DESCRIPTION
Referenz auf Agenten in Desires und SubDesires hinzugefügt, um an dessen Beliefs heranzukommen.

Access modifier der getter in Beliefs auf public gesetzt, damit auf diese von den SubDesires aus zugegriffen werden kann. (Die SubDesires befinden sich aktuell in einem anderen Paket.)

Bitte meldet euch wenn ihr eine bessere Lösung seht.