### PR TITLE
Fix debug ausgabe context creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ logs/AgentLogger.log
 *.aux
 *.synctex.gz
 *.toc
+.idea

--- a/src/main/java/de/feu/massim22/group3/map/PathFinder.java
+++ b/src/main/java/de/feu/massim22/group3/map/PathFinder.java
@@ -57,8 +57,7 @@ class PathFinder {
         long win = glfwCreateWindow(200, 200, buf, 0, 0);
         glfwMakeContextCurrent(win);
         GL.createCapabilities();
-        glfwMakeContextCurrent(0);
-        
+
         // Log OpenGL Details
         StringBuilder b = new StringBuilder()
         .append("GL_VENDOR: " + glGetString(GL_VENDOR))
@@ -67,6 +66,8 @@ class PathFinder {
         .append(System.lineSeparator())
         .append("GL_VERSION: " + glGetString(GL_VERSION));
         AgentLogger.fine(b.toString());
+
+        glfwMakeContextCurrent(0);
 
         return win;
     } 


### PR DESCRIPTION
@h1Modeling 

Hier der Fix der die korrekten Ausgaben für  GL_VENDOR, GL_RENDERER unf GL_VERSION ermöglicht.

Du hattest ja gesagt, ich solle diese Ausgabe ins init verlegen. Du meinst damit in die Pathfinder.init() oder in den Navi Constructor?
dann müsste man dort aber die createOpenGlContext() einmal aufraufen ( ggf. mit einem Parameter der die Logausgabe ermöglicht, die dann standarmäßig nicht mehr erfolgt), denn die genannten Infos koennen nur ermittelt werden, wenn gerade ein Current Context existiert.