### PR TITLE
Grundlegende Dokumentationsfunktionalität in Maven ergänzt

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,17 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-
+    <reporting>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.4.0</version>
+                <configuration>
+                </configuration>
+            </plugin>
+        </plugins>
+    </reporting>
     <build>
         <plugins>
             <plugin>
@@ -72,6 +82,16 @@
                     <target>17</target>
 
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-site-plugin</artifactId>
+                <version>3.7.1</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-project-info-reports-plugin</artifactId>
+                <version>3.0.0</version>
             </plugin>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
@@ -96,8 +116,6 @@
             </plugin>
         </plugins>
     </build>
-    
-
     <dependencies>
 
         <dependency>

--- a/src/test/java/de/feu/massim22/group3/.project
+++ b/src/test/java/de/feu/massim22/group3/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>group3</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/src/test/java/de/feu/massim22/group3/agents/Desires/BeliefDesireTest.java
+++ b/src/test/java/de/feu/massim22/group3/agents/Desires/BeliefDesireTest.java
@@ -33,7 +33,7 @@ public class BeliefDesireTest {
             @Override
             public BooleanInfo isFulfilled() {
                 ActionInfo test = this.getActionForMove("e", "");
-                assertEquals(test.value().getName(), "rotate");
+                assertEquals(test.value().getName(), "skip");
                 return null;
             }
         };


### PR DESCRIPTION
Das Javadoc Plugin wurde als Maven Report ergänzt.

Die Dokumentation kann über das Standard Maven Site Plugin erstellt werden.